### PR TITLE
Fix typo in grunt options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ assemble: {
     compose: {
       cwd: 'test/fixtures/includes',
       sep: '<!-- include -->',
-      compare_fn: function(a, b) {
+      compare: function(a, b) {
         return a.index >= b.index ? 1 : -1;
       }
     }


### PR DESCRIPTION
"compare_fn" -> "compare" (per source: https://github.com/helpers/handlebars-helper-compose/blob/master/index.js#L43 )
