### PR TITLE
handle case where options.marked is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports.register = function (Handlebars, options, params) {
   opts.compose = opts.compose || {};
   var customMarkedOpts = _.extend(options.marked || {});
 
-  extras.init(options.marked);
+  extras.init(customMarkedOpts);
   var markedOpts = _.defaults(customMarkedOpts, extras.markedDefaults);
 
 


### PR DESCRIPTION
little fix for when no marked options are set.  see https://github.com/helpers/handlebars-helper-compose/commit/c1a3187418963ec2d2d45239687e2b9d47f44157#commitcomment-5137128 and https://github.com/helpers/handlebars-helper-compose/issues/12#issuecomment-33143179
