### PR TITLE
revert marked-extras back to 0.2 reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "globule": "~0.2.0",
     "lodash": "~2.4.0",
     "marked": "0.3.0",
-    "marked-extras": "~0.1.1",
+    "marked-extras": "~0.2.0",
     "underscore.string": "~2.3.3",
     "gray-matter": "~0.2.6"
   },


### PR DESCRIPTION
Hi,

you reverted the reference to marked-extras back to 0.1 which is why the css is not getting highlighted on less-docs.

This reverts it back.
